### PR TITLE
cast obj to float before fabs

### DIFF
--- a/src/zope/i18n/format.py
+++ b/src/zope/i18n/format.py
@@ -422,7 +422,7 @@ class NumberFormat(object):
                 roundInt = False
             if roundInt:
                 obj = roundHalfUp(obj)
-            integer = self._format_integer(str(int(math.fabs(obj))),
+            integer = self._format_integer(str(int(math.fabs(float(obj)))),
                                            bin_pattern[INTEGER])
             # Adding grouping
             if bin_pattern[GROUPING] == 1:


### PR DESCRIPTION
No existing tests break with casting the obj to float before calling math.fabs.
