### PR TITLE
Fixed date/time format in zh.xml, sv.xml and es_US.xml

### DIFF
--- a/src/zope/i18n/locales/data/es_US.xml
+++ b/src/zope/i18n/locales/data/es_US.xml
@@ -35,12 +35,12 @@
 					</dateFormatLength >
 					<dateFormatLength type="medium">
 						<dateFormat >
-							<pattern>MMM d, yyyy</pattern>
+							<pattern>dd-MMM-yy</pattern>
 						</dateFormat>
 					</dateFormatLength >
 					<dateFormatLength type="short">
 						<dateFormat >
-							<pattern>M/d/yy</pattern>
+							<pattern>d/MM/yy</pattern>
 						</dateFormat>
 					</dateFormatLength >
 				</dateFormats>
@@ -48,22 +48,22 @@
 					<default type="medium"/>
 					<timeFormatLength type="full">
 						<timeFormat >
-							<pattern>h:mm:ss a z</pattern>
+							<pattern>HH'H'mm''ss" z</pattern>
 						</timeFormat>
 					</timeFormatLength >
 					<timeFormatLength type="long">
 						<timeFormat >
-							<pattern>h:mm:ss a z</pattern>
+							<pattern>HH:mm:ss z</pattern>
 						</timeFormat>
 					</timeFormatLength >
 					<timeFormatLength type="medium">
 						<timeFormat >
-							<pattern>h:mm:ss a</pattern>
+							<pattern>HH:mm:ss</pattern>
 						</timeFormat>
 					</timeFormatLength >
 					<timeFormatLength type="short">
 						<timeFormat >
-							<pattern>h:mm a</pattern>
+							<pattern>HH:mm</pattern>
 						</timeFormat>
 					</timeFormatLength >
 				</timeFormats>

--- a/src/zope/i18n/locales/data/sv.xml
+++ b/src/zope/i18n/locales/data/sv.xml
@@ -902,12 +902,12 @@
 					</dateFormatLength >
 					<dateFormatLength type="medium">
 						<dateFormat >
-							<pattern>yyyy-MM-dd</pattern>
+							<pattern>dd-MMM-yy</pattern>
 						</dateFormat>
 					</dateFormatLength >
 					<dateFormatLength type="short">
 						<dateFormat >
-							<pattern>yyyy-MM-dd</pattern>
+							<pattern>d/MM/yy</pattern>
 						</dateFormat>
 					</dateFormatLength >
 				</dateFormats>

--- a/src/zope/i18n/locales/data/zh.xml
+++ b/src/zope/i18n/locales/data/zh.xml
@@ -883,6 +883,54 @@
 						<era type="2">公元</era>
 					</eraAbbr>
 				</eras>
+				<dateFormats>
+					<default type="medium"/>
+					<dateFormatLength type="full">
+						<dateFormat >
+							<pattern>yyyy'年'M'月'd'日'EEEE</pattern>
+						</dateFormat>
+					</dateFormatLength >
+					<dateFormatLength type="long">
+						<dateFormat >
+							<pattern>yyyy'年'M'月'd'日'</pattern>
+						</dateFormat>
+					</dateFormatLength >
+					<dateFormatLength type="medium">
+						<dateFormat >
+							<pattern>yyyy/MM/dd</pattern>
+						</dateFormat>
+					</dateFormatLength >
+					<dateFormatLength type="short">
+						<dateFormat >
+							<pattern>yy/MM/dd</pattern>
+						</dateFormat>
+					</dateFormatLength >
+				</dateFormats>
+				<timeFormats>
+					<default type="medium"/>
+					<timeFormatLength type="long">
+						<timeFormat >
+							<pattern>H:mm:ss:z</pattern>
+						</timeFormat>
+					</timeFormatLength >
+					<timeFormatLength type="medium">
+						<timeFormat >
+							<pattern>H:mm:ss</pattern>
+						</timeFormat>
+					</timeFormatLength >
+					<timeFormatLength type="short">
+						<timeFormat >
+							<pattern>H:mm</pattern>
+						</timeFormat>
+					</timeFormatLength >
+				</timeFormats>
+				<dateTimeFormats>
+					<dateTimeFormatLength >
+						<dateTimeFormat>
+							<pattern>{1} {0}</pattern>
+						</dateTimeFormat>
+					</dateTimeFormatLength >
+				</dateTimeFormats>
 			</calendar>
 		</calendars>
 		<timeZoneNames>


### PR DESCRIPTION
Fixed gregorian calendar date/time format issue in following language/geo:
- es_US.xml date/time format should be consistent with Spanish default format (see [es.xml](https://github.com/zopefoundation/zope.i18n/blob/master/src/zope/i18n/locales/data/es.xml#L624-L669) for reference)
- sv.xml date format should be in the order of day-month-year, instead of year-month-day
- zh.xml is missing default date/time format, should follow similar format as Japanese (see [ja.xml](https://github.com/zopefoundation/zope.i18n/blob/master/src/zope/i18n/locales/data/ja.xml#L591-L636) for reference)
