### PR TITLE
Make interpolate working recursively.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,11 @@
 CHANGES
 =======
 
-4.0.2 (unreleased)
---------------------
+4.1.0 (unreleased)
+------------------
 
-- TBD
-
+- ``interpolate()`` now works recursively, if the mapping has a value which is
+  a ``zope.i18nmessageid.Message`` itself.
 
 4.0.1 (2015-06-05)
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def alltests():
 
 setup(
     name='zope.i18n',
-    version='4.0.2.dev0',
+    version='4.1.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     description='Zope Internationalization Support',

--- a/src/zope/i18n/__init__.py
+++ b/src/zope/i18n/__init__.py
@@ -160,11 +160,22 @@ def interpolate(text, mapping=None):
 
     >>> interpolate(_u("This is ${name}"))
     u'This is ${name}'
+
+    If a mapping value is a message id itself it is interpolated, too:
+
+    >>> from zope.i18nmessageid import Message
+    >>> interpolate(_u("This is $meta."),
+    ...             mapping={'meta': Message(_u("$name $version"),
+    ...                                      mapping=mapping)})
+    u'This is Zope 3.'
     """
 
     def replace(match):
         whole, param1, param2 = match.groups()
-        return unicode(mapping.get(param1 or param2, whole))
+        value = mapping.get(param1 or param2, whole)
+        if isinstance(value, Message):
+            value = interpolate(value, value.mapping)
+        return unicode(value)
 
     if not text or not mapping:
         return text


### PR DESCRIPTION
If the mapping has a value which is a zope.i18nmessageid.Message itself, it gets interpolated, too.

Version 3.5.0 introduced this behaviour for translations, porting it to interpolation here.