### PR TITLE
Provided better error message on PO-File syntax errors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 4.2.0 (unreleased)
 ------------------
 
+- Better errot message on PO-File Syntax Errors.
+  [SyZn]
+
 - Add support for Python 3.5.
 
 - Drop support for Python 2.6 and 3.2.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 4.2.0 (unreleased)
 ------------------
 
-- Better errot message on PO-File Syntax Errors.
+- Better error message on PO-File Syntax Errors.
   [SyZn]
 
 - Add support for Python 3.5.

--- a/src/zope/i18n/compile.py
+++ b/src/zope/i18n/compile.py
@@ -43,5 +43,7 @@ def compile_mo_file(domain, lc_messages_path):
             fd = open(mofile, 'wb')
             fd.write(mo.read())
             fd.close()
-        except (IOError, OSError, PoSyntaxError) as err:
-            logger.warn('Error while compiling %s (%s).' % (pofile, err.msg))
+        except PoSyntaxError as err:
+            logger.warn('Syntax error while compiling %s (%s).' % (pofile, err.msg))
+        except (IOError, OSError):
+            logger.warn('Error while compiling %s.' % pofile)

--- a/src/zope/i18n/compile.py
+++ b/src/zope/i18n/compile.py
@@ -45,5 +45,5 @@ def compile_mo_file(domain, lc_messages_path):
             fd.close()
         except PoSyntaxError as err:
             logger.warn('Syntax error while compiling %s (%s).' % (pofile, err.msg))
-        except (IOError, OSError):
-            logger.warn('Error while compiling %s.' % pofile)
+        except (IOError, OSError) as err:
+            logger.warn('Error while compiling %s (%s).' % (pofile, err))

--- a/src/zope/i18n/compile.py
+++ b/src/zope/i18n/compile.py
@@ -43,5 +43,5 @@ def compile_mo_file(domain, lc_messages_path):
             fd = open(mofile, 'wb')
             fd.write(mo.read())
             fd.close()
-        except (IOError, OSError, PoSyntaxError):
-            logger.warn('Error while compiling %s' % pofile)
+        except (IOError, OSError, PoSyntaxError) as err:
+            logger.warn('Error while compiling %s (%s).' % (pofile, err.msg))


### PR DESCRIPTION
This fix provides better error messages on Syntax Errors in PO files. It makes it easier to find the location (line number) of the error in the po file.
