### PR TITLE
Fix default plural (again)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.6.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix ``default_plural`` again if a ``zope.i18n.messageid.Message`` is
+  used with ``translate()``.
 
 
 4.6.0 (2018-10-22)

--- a/src/zope/i18n/translationdomain.py
+++ b/src/zope/i18n/translationdomain.py
@@ -102,7 +102,7 @@ class TranslationDomain(object):
 
         # Recursively translate mappings, if they are translatable
         if (mapping is not None
-            and Message in (type(m) for m in mapping.values())):
+                and Message in (type(m) for m in mapping.values())):
             if seen is None:
                 seen = set()
             seen.add((msgid, msgid_plural))
@@ -121,6 +121,8 @@ class TranslationDomain(object):
 
         if default is None:
             default = text_type(msgid)
+        if msgid_plural is not None and default_plural is None:
+            default_plural = text_type(msgid_plural)
 
         # Get the translation. Use the specified fallbacks if this fails
         catalog_names = self._catalogs.get(target_language)


### PR DESCRIPTION
Fix a followup fix to https://github.com/zopefoundation/zope.i18n/pull/35. Turns out there's code duplication in the package, so I had to duplicate the fix...

I tested this change with the test of my application that are now all green, so that should correct for real this time. All of this is related to the fact we used to have ``default_plural`` falls back to ``msgid_plural`` in ``zope.i18nmessageid``, but we removed that while processing pull request review, and I did not properly test the changes coming out of this in my application, sorry.

If you are happy with the fix could I ask for a 4.6.1 release as well? Or you can add me on pypi, my user is ``thefunny42``.