### PR TITLE
Fix the signature of IMessageCatalog.getPluralMessage()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Drop Python 3.4 support.
 
+- Fix the signature of ``IMessageCatalog.getPluralMessage()``.  See `issue 41
+  <https://zopefoundation/zope.i18n/issue/41>`_.
+
 
 4.6.2 (2019-02-19)
 ==================

--- a/src/zope/i18n/interfaces/__init__.py
+++ b/src/zope/i18n/interfaces/__init__.py
@@ -60,14 +60,14 @@ class IMessageCatalog(Interface):
 
         An exception is raised if the message id is not found.
         """
-        
+
     def queryMessage(msgid, default=None):
         """Look for the appropriate text for the given message id.
 
         If the message id is not found, default is returned.
         """
 
-    def getPluralMessage(self, singular, plural, n):
+    def getPluralMessage(singular, plural, n):
         """Get the appropriate text for the given message id and the
         plural id.
 
@@ -328,7 +328,7 @@ class IFormat(Interface):
 
 
 class INumberFormat(IFormat):
-    """Specific number formatting interface. Here are the formatting
+    r"""Specific number formatting interface. Here are the formatting
     rules (I modified the rules from ICU a bit, since I think they did not
     agree well with the real world XML formatting strings):
 


### PR DESCRIPTION
Fixes #41.

Also make sure we don't include literal U+0000 and U+FFFD characters in the docstring of INumberFormat on Python 3 were \u is a real escape sequence in non-u-prefixed tripple-quoted strings.