### PR TITLE
Fix problems with zope_i18n_compile_mo_files early assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.8.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix problems with ``zope_i18n_compile_mo_files`` early assignment to
+  module variable in ``config.py`` in a non-breaking way.
+  See also `Zope issue #994 <https://github.com/zopefoundation/Zope/issues/994>`_
 
 
 4.8.0 (2021-09-07)

--- a/src/zope/i18n/config.py
+++ b/src/zope/i18n/config.py
@@ -6,7 +6,13 @@ import os
 COMPILE_MO_FILES_KEY = 'zope_i18n_compile_mo_files'
 #: Whether or not the ZCML directives will attempt to compile
 #: translation files. Defaults to False.
-COMPILE_MO_FILES = os.environ.get(COMPILE_MO_FILES_KEY, False)
+
+
+def _getter_compile_mo_files():
+    return os.environ.get(COMPILE_MO_FILES_KEY, False)
+
+
+COMPILE_MO_FILES = property(_getter_compile_mo_files)
 
 #: The environment variable that is consulted when this module
 #: is imported to determine the value of `ALLOWED_LANGUAGES`.


### PR DESCRIPTION
see https://github.com/zopefoundation/Zope/issues/994

Using a property here is a way to not break backward compatibility. 
Given a case where someone imports `config` and set the variable: This still works.