### PR TITLE
Fix problems with zope_i18n_compile_mo_files early assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.8.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix problems with ``zope_i18n_compile_mo_files`` early assignment to
+  module variable in ``config.py`` in a non-breaking way.
+  See also `Zope issue #994 <https://github.com/zopefoundation/Zope/issues/994>`_
 
 
 4.8.0 (2021-09-07)

--- a/src/zope/i18n/config.py
+++ b/src/zope/i18n/config.py
@@ -4,9 +4,10 @@ import os
 #: is imported to determine the value of `COMPILE_MO_FILES`.
 #: Simply set this to a non-empty string to make it True.
 COMPILE_MO_FILES_KEY = 'zope_i18n_compile_mo_files'
+COMPILE_MO_FILES_UNSET = "__unset__"
 #: Whether or not the ZCML directives will attempt to compile
 #: translation files. Defaults to False.
-COMPILE_MO_FILES = os.environ.get(COMPILE_MO_FILES_KEY, False)
+COMPILE_MO_FILES = COMPILE_MO_FILES_UNSET
 
 #: The environment variable that is consulted when this module
 #: is imported to determine the value of `ALLOWED_LANGUAGES`.

--- a/src/zope/i18n/zcml.py
+++ b/src/zope/i18n/zcml.py
@@ -89,7 +89,14 @@ def registerTranslations(_context, directory, domain='*'):
         lc_messages_path = os.path.join(path, language, 'LC_MESSAGES')
         if os.path.isdir(lc_messages_path):
             # Preprocess files and update or compile the mo files
-            if config.COMPILE_MO_FILES:
+            setting_unset = (
+                config.COMPILE_MO_FILES == config.COMPILE_MO_FILES_UNSET
+            )
+            if (
+                (setting_unset
+                 and os.environ.get(config.COMPILE_MO_FILES_KEY, False))
+                or (not setting_unset and config.COMPILE_MO_FILES)
+            ):
                 for domain_path in glob(os.path.join(lc_messages_path,
                                                      '%s.po' % domain)):
                     domain_file = os.path.basename(domain_path)


### PR DESCRIPTION
see zopefoundation/Zope#994

2nd try - still trying not to break backward compatibility with the case if people importing the module and using it to configure the behavior.