### PR TITLE
Skip the circular reference test for zope.i18nmessageid >= 7

### DIFF
--- a/src/zope/i18n/tests/test_translationdomain.py
+++ b/src/zope/i18n/tests/test_translationdomain.py
@@ -13,9 +13,9 @@
 ##############################################################################
 """This module tests the regular persistent Translation Domain.
 """
+import importlib.metadata
 import os
 import unittest
-import importlib.metadata
 
 import zope.component
 from zope.i18nmessageid import MessageFactory


### PR DESCRIPTION
Fixes #62.

Open issues:

- [ ] change log entry