### PR TITLE
fix test incompatibility for `zope.i18nmessageid >= 7.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Drop support for Python 3.7.
 
+- Fix test incompatibility for ``zope.i18nmessageid >= 7.0``
+  (`#62 <https://github.com/zopefoundation/zope.i18n/issues/62>`_).
+
 
 5.1 (2023-08-28)
 ================

--- a/src/zope/i18n/tests/test_translationdomain.py
+++ b/src/zope/i18n/tests/test_translationdomain.py
@@ -113,10 +113,17 @@ class TestGlobalTranslationDomain(TestITranslationDomain, unittest.TestCase):
                          mapping={})
         msgid2 = factory("48-not-there", 'Message 2 and $msg1',
                          mapping={})
-        msgid1.mapping['msg2'] = msgid2
-        msgid2.mapping['msg1'] = msgid1
-        self.assertRaises(ValueError,
-                          translate, msgid1, None, None, 'en', "default")
+        try:
+            msgid1.mapping['msg2'] = msgid2
+            msgid2.mapping['msg1'] = msgid1
+        except TypeError:
+            # this is a `zope.i118nmessageid >= 7` message id enforcing
+            # immutability; circular references therefore
+            # cannot be created in this way
+            pass
+        else:
+            self.assertRaises(ValueError,
+                              translate, msgid1, None, None, 'en', "default")
         # Recursive translations also work if the original message id wasn't a
         # message id but a Unicode with a directly passed mapping
         self.assertEqual(


### PR DESCRIPTION
fixed #62.